### PR TITLE
Made generateConfig public and switched order of merge

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import externalGlobals from 'rollup-plugin-external-globals';
  *
  * @returns {import('rollup').RollupOptions}
  */
-function generateConfig(manifest) {
+export function generateConfig(manifest) {
     return {
         input: './src/index.tsx',
         plugins: [
@@ -73,5 +73,5 @@ export default function deckyPlugin(options = {}, sourceRoot = ".") {
     const manifest = JSON.parse(readFileSync(join(sourceRoot, "plugin.json"), "utf-8"));
     const defaultOptions = generateConfig(manifest);
 
-    return mergeAndConcat(options, defaultOptions)
+    return mergeAndConcat(defaultOptions, options)
 }


### PR DESCRIPTION
My config requires plugins ordered in a particular order which makes using the preset as it is right now impossible.
```ts
import plugin from "./plugin.json" with { type: "json" };

export default defineConfig(merge(
	deckyPlugin(),
	{
		plugins: [
			nodeResolve({ browser: true }),
			codegen.default(),
			mdx({ providerImportSource: '@mdx-js/react' }),
			commonjs(),
			json(),
			typescript(),
			externalGlobals({
				react: 'SP_REACT',
				'react-dom': 'SP_REACTDOM',
				'@decky/ui': 'DFL',
				'@decky/manifest': JSON.stringify(plugin)
			}),
			replace({
				preventAssignment: false,
				'process.env.NODE_ENV': JSON.stringify('production'),
			}),
			importAssets({
				publicPath: `http://127.0.0.1:1337/plugins/${plugin.name}/`
			})
		],
	}
));
```

To help with this I propose 2 changes
* export the `generateConfig` method so the file reading can be skipped if the config is already known:
```ts
import plugin from "./plugin.json" with { type: "json" };

export default defineConfig(merge(
	generateConfig(plugin),
	...
	)
)
```
* Switch around the order the arguments are provided to `mergeAndConcat` which means that the provided arguments actually override the base argument.
```ts
// Should override input with "test.ts" rather than the default
deckyPlugin({input: "test.ts"});
```